### PR TITLE
Make minor changes for handling ACE projects

### DIFF
--- a/annotation-utils/src/main/java/edu/isi/vista/annotationutils/ExportAnnotations.kt
+++ b/annotation-utils/src/main/java/edu/isi/vista/annotationutils/ExportAnnotations.kt
@@ -169,10 +169,10 @@ class ExportAnnotations {
                         ZipFile(annotationsInMemoryZip).use {
                             // filename manipulation is to work around
                             // https://github.com/inception-project/inception/issues/1174
-                            val firstDotInDocumentNameIndex = document.name.indexOf('.')
+                            val lastDotInDocumentNameIndex = document.name.lastIndexOf('.')
                             // note documents cannot have empty names
-                            val zipEntryName = if (firstDotInDocumentNameIndex >= 0) {
-                                document.name.substring(0, firstDotInDocumentNameIndex)
+                            val zipEntryName = if (lastDotInDocumentNameIndex >= 0) {
+                                document.name.substring(0, lastDotInDocumentNameIndex)
                             } else {
                                 document.name
                             }

--- a/annotation-utils/src/main/java/edu/isi/vista/annotationutils/ExtractAnnotationStats.kt
+++ b/annotation-utils/src/main/java/edu/isi/vista/annotationutils/ExtractAnnotationStats.kt
@@ -83,20 +83,35 @@ class ExtractAnnotationStats {
 
                         if (it.isFile) {
                             val folder = it.parent
+                            logger.info { "Folder: $folder"}
                             // Get the username from the parent directory
                             // by finding the characters after the pattern "type.subtype-"
                             // e.g. Conflict.Attack-(gabbard)
-                            val userPattern = Regex(pattern = """\.\w+-(\w+)""")
-                            val user = userPattern
-                                    .find(input = folder)!!.groupValues[1]
-                            // Get the event type from the parent directory
-                            // by finding the characters before the pattern "-username"
-                            // e.g. (Conflict.Attack)-gabbard
-                            // Some directory names include an additional word or phrase (\w*?\.?)
-                            // or a language indicator (w*?-?)
-                            val eventTypePattern = Regex(pattern = """\w+?-?\w+\.?\w+\.\w+""")
-                            val eventType = eventTypePattern
-                                    .find(input = folder)!!.value
+                            // An ACE file could have two directory name formats:
+                            // 1. ACE-Event.Type-username
+                            // 2. ACE-Hyphenated.Event-Type-username
+                            val aceHyphenatedPattern = Regex(pattern = """(ACE-\w+\.\w+-\w+)-(\w+)""")
+                            val user: String?
+                            val eventType: String?
+                            if (folder.contains(aceHyphenatedPattern)) {
+                                eventType = aceHyphenatedPattern
+                                        .find(input = folder)!!.groupValues[1]
+                                user = aceHyphenatedPattern
+                                        .find(input = folder)!!.groupValues[2]
+                            }
+                            else {
+                                val userPattern = Regex(pattern = """\.\w+-(\w+)""")
+                                user = userPattern
+                                        .find(input = folder)!!.groupValues[1]
+                                // Get the event type from the parent directory
+                                // by finding the characters before the pattern "-username"
+                                // e.g. (Conflict.Attack)-gabbard
+                                // Some directory names include an additional word or phrase (\w*?\.?)
+                                // or a language indicator (w*?-?)
+                                val eventTypePattern = Regex(pattern = """\w+?-?\w+\.?\w+\.\w+""")
+                                eventType = eventTypePattern
+                                        .find(input = folder)!!.value
+                            }
                             if (user.isBlank() || eventType.isBlank()) {
                                 throw RuntimeException(
                                         "Missing annotation information (user/subtype) for $it")

--- a/annotation-utils/src/main/java/edu/isi/vista/annotationutils/ExtractAnnotationStats.kt
+++ b/annotation-utils/src/main/java/edu/isi/vista/annotationutils/ExtractAnnotationStats.kt
@@ -83,7 +83,6 @@ class ExtractAnnotationStats {
 
                         if (it.isFile) {
                             val folder = it.parent
-                            logger.info { "Folder: $folder"}
                             // Get the username from the parent directory
                             // by finding the characters after the pattern "type.subtype-"
                             // e.g. Conflict.Attack-(gabbard)


### PR DESCRIPTION
Closes #64 

* Slightly changes method for getting `zipEntryName` due to differences in ACE document names
* Adds procedure for extracting info from ACE projects with hyphenated event type names (e.g. `Business.Declare-Bankruptcy`)