### PR TITLE
73 collect times users spend on annotation

### DIFF
--- a/annotation-utils/src/main/java/edu/isi/vista/annotationutils/ExtractAnnotationStats.kt
+++ b/annotation-utils/src/main/java/edu/isi/vista/annotationutils/ExtractAnnotationStats.kt
@@ -616,7 +616,7 @@ class ExtractAnnotationStats {
                                             td {}
                                         }
                                         td {+project}
-                                        td {+projectSentenceCount}
+                                        td {+"$projectSentenceCount"}
                                         td {+totalTime}
                                         if (secondsDiff != null){
                                             td {+secondsToHMS(secondsDiff)}
@@ -653,7 +653,6 @@ private fun getSentenceCountsByProject(sentenceList: List<SentenceAnnotation>): 
     val sentencesByUser = sentenceList.groupBy { it.user }
     val projectCounts = mutableMapOf<String, Int>()
     for (user in sentencesByUser) {
-        logger.info { "user = $user" }
         val username = user.key
         val eventTypeCountsForUser = user.value.countBy { it.eventType }
         for (eventType in eventTypeCountsForUser) {

--- a/annotation-utils/src/main/java/edu/isi/vista/annotationutils/ExtractAnnotationStats.kt
+++ b/annotation-utils/src/main/java/edu/isi/vista/annotationutils/ExtractAnnotationStats.kt
@@ -34,6 +34,9 @@ class ExtractAnnotationStats {
             extractStats(params)
         }
         fun extractStats(params: edu.isi.nlp.parameters.Parameters) {
+            // Generate a user annotation time report
+            GetAnnotationDurations.getDurations(params)
+            // Get params for the HTML stats report
             val exportAnnotationRoot = params.getExistingDirectory("exportedAnnotationRoot")
             val timeReportRoot = params.getExistingDirectory("timeReportRoot")
             val statisticsDirectory = params.getExistingDirectory("statisticsDirectory")
@@ -123,7 +126,7 @@ class ExtractAnnotationStats {
                     }
                     .forEach {
 
-                        if (it.isFile) {
+                        if (it.isFile && it.name != EVENT_LOG) {
                             logger.info { "Now processing $it" }
                             val folder = it.parent
                             // Get the username from the parent directory

--- a/annotation-utils/src/main/java/edu/isi/vista/annotationutils/GetAnnotationDurations.kt
+++ b/annotation-utils/src/main/java/edu/isi/vista/annotationutils/GetAnnotationDurations.kt
@@ -56,7 +56,7 @@ fun main(argv: Array<String>) {
             val projectInfo = getProjectInfo(projectName)
             // Each project should have a file named `event.log` - this
             // stores the timestamps of each "event" made in the project.
-            val eventLog = File(projectDir.toString(), "event.log")
+            val eventLog = File(projectDir.toString(), EVENT_LOG)
             if (eventLog.exists() && projectInfo != null) {
                 val username = projectInfo.username
                 val eventType = projectInfo.eventType

--- a/annotation-utils/src/main/java/edu/isi/vista/annotationutils/GetAnnotationDurations.kt
+++ b/annotation-utils/src/main/java/edu/isi/vista/annotationutils/GetAnnotationDurations.kt
@@ -1,0 +1,123 @@
+package edu.isi.vista.annotationutils
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import edu.isi.nlp.parameters.serifstyle.SerifStyleParameterFileLoader
+import java.io.File
+
+/**
+ * Script for getting the annotation time information from event.log files
+ *
+ * This takes a parameter file with two required parameters:
+ * <ul>
+ *   <li> `exportAnnotationRoot` - the output of ExportAnnotations </li>
+ *   <li> `timeReportRoot` - the location where time reports will be saved </li>
+ * </ul>
+ *
+ */
+
+fun main(argv: Array<String>) {
+    if (argv.size != 1) {
+        throw RuntimeException("Expected a single argument: a parameter file")
+    }
+    val paramsLoader = SerifStyleParameterFileLoader.Builder().build()
+    val params = paramsLoader.load(File(argv[0]))
+
+    val exportedAnnotationRoot = params.getExistingDirectory("exportedAnnotationRoot")
+    val timeReportRoot = params.getCreatableDirectory("timeReportRoot").toPath()
+
+    // Make objects for reading, parsing, and writing json:
+    val objectMapper = ObjectMapper()
+    val prettyPrinter = objectMapper.writerWithDefaultPrettyPrinter()
+
+    // Mapping of users to projects to times
+    // These will be printed to the output file.
+    // {"gabbard": {"Conflict.Attack": {"seconds": 120, "formatted": "0h:2m:0s"}}}
+    val durationMap = mutableMapOf<String, Map<String, Map<String, Any>>>()
+
+    exportedAnnotationRoot.walk().filter {it.isDirectory}.forEach { projectDir ->
+        val projectName = projectDir.name
+        logger.info { "ProjectName: $projectName"}
+        if (projectName != exportedAnnotationRoot.name) {
+            var eventType: String? = null
+            var username: String? = null
+            if (projectName.startsWith("ACE")) {
+                // Example ACE project name: ACE-Business.Declare-Bankruptcy-gabbard
+                val acePattern = Regex(pattern = """(ACE-[a-zA-Z]*\.[a-zA-Z]*-?[a-zA-Z]*?)-(.*)""")
+                if (acePattern.containsMatchIn(projectName)) {
+                    val aceMatch = acePattern.find(projectName)
+                    eventType = aceMatch!!.groups[1]!!.value
+                    username = aceMatch.groups[2]!!.value
+                }
+            }
+            // TODO: add other filename patterns
+            else {
+                logger.info { "Script still under construction!" }
+            }
+            val eventLog = File(projectDir.toString(), "event.log")
+            logger.info { "logfile = $eventLog" }
+            if (eventLog.exists() && eventType != null && username != null) {
+                // Read event.log
+                val jsonEvents = getEventsAsJson(eventLog)
+
+
+                // Get times spent in each document by running
+                // through each Inception event
+                var currentDocument: String? = null  // some events have no document field
+                var previousTime: Long = 0
+                var documentTimeElapsed: Long = 0
+                val documentTimeMap = mutableMapOf<String, Long>().withDefault { 0 }
+                for (event in jsonEvents) {
+                    val documentName = event.get("document_name")?.toString()?.removeSurrounding("\"")
+                    val annotator = event.get("annotator")?.toString()?.removeSurrounding("\"")
+                    // Only deal with events that have a "document_name" field
+                    // and involve the current annotator
+                    if (documentName != null && annotator == username) {
+                        logger.info {"On $username's $documentName"}
+                        val timestamp = event.get("created").toString().toLong()
+                        val timeSinceLastEvent = timestamp - previousTime
+                        if (previousTime == 0.toLong()) {
+                            // This is the first event in the log
+                            currentDocument = documentName
+                        } else if (documentName == currentDocument) {
+                            // The user has not changed documents.
+                            // Check if the time elapsed since the last
+                            // event makes is less than 10 minutes -
+                            // else don't add it to the
+                            // overall time spent on the document.
+                            if (timeSinceLastEvent < 600000) {
+                                documentTimeElapsed += timeSinceLastEvent
+                            }
+                        } else {
+                            // The user has entered a new document.
+                            // Record the time elapsed and restart the "timer"
+                            logger.info { "Total time elapsed in $currentDocument: $documentTimeElapsed" }
+                            val previousDocumentTime = documentTimeMap[currentDocument.toString()]
+                            if (previousDocumentTime != null) {
+                                documentTimeMap[currentDocument.toString()] = previousDocumentTime + documentTimeElapsed
+                            }
+                            logger.info { "Document times now: $documentTimeMap" }
+                            documentTimeElapsed = 0
+                            currentDocument = documentName
+                        }
+                        previousTime = timestamp
+                    }
+                }
+                logger.info {"Document times now: $documentTimeMap"}
+
+
+            } else {
+                logger.info { "No event.log for $projectName" }
+            }
+        }
+    }
+}
+
+private fun getEventsAsJson(log: File): List<JsonNode> {
+    // Each line in an event.log represents an action in
+    // Inception, and these can be converted
+    // to JSON objects.
+    val eventObjectMapper = ObjectMapper()
+    val logEvents = log.readLines()
+    return logEvents.map {eventObjectMapper.readTree(it)}
+}

--- a/annotation-utils/src/main/java/edu/isi/vista/annotationutils/GetAnnotationDurations.kt
+++ b/annotation-utils/src/main/java/edu/isi/vista/annotationutils/GetAnnotationDurations.kt
@@ -177,6 +177,7 @@ private fun getTimeOnProject(logEvents: List<JsonNode>, username: String): Long 
         // and were completed by the user
         // (admin monitoring activity also gets recorded)
         if (documentName != null && user == username) {
+            // Timestamps are in Unix time (milliseconds)
             val timestamp = event.get("created").toString().toLong()
             val timeSinceLastEvent = timestamp - previousTime
             if (previousTime == 0.toLong()) {
@@ -210,7 +211,7 @@ private fun getTimeOnProject(logEvents: List<JsonNode>, username: String): Long 
         }
     }
     // All events in this Inception project have been processed.
-    // Sum up the times from each time to get the total time
+    // Sum up the times from each document to get the total time
     // spent on this project.
     return documentTimeMap.map { it.value }.sum()/1000
 }

--- a/annotation-utils/src/main/java/edu/isi/vista/annotationutils/GetAnnotationDurations.kt
+++ b/annotation-utils/src/main/java/edu/isi/vista/annotationutils/GetAnnotationDurations.kt
@@ -4,10 +4,20 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import edu.isi.nlp.parameters.serifstyle.SerifStyleParameterFileLoader
 import java.io.File
+import java.text.SimpleDateFormat
+import java.util.*
 import java.util.concurrent.TimeUnit
 
 /**
  * Script for getting the annotation time information from event.log files
+ *
+ * The output is a .json file containing a list of each annotator's
+ * projects and how long they have spent on each one, with the times
+ * written in both seconds and an hours:minutes:seconds format.
+ *
+ * For this script to work, the event.log files should be saved in
+ * their respective exported project files
+ * (`.../exported/Event.Type-user_name/event.log`)
  *
  * This takes a parameter file with two required parameters:
  * <ul>
@@ -21,139 +31,80 @@ fun main(argv: Array<String>) {
     if (argv.size != 1) {
         throw RuntimeException("Expected a single argument: a parameter file")
     }
+    // Load parameters
     val paramsLoader = SerifStyleParameterFileLoader.Builder().build()
     val params = paramsLoader.load(File(argv[0]))
-
     val exportedAnnotationRoot = params.getExistingDirectory("exportedAnnotationRoot")
-    val timeReportRoot = params.getCreatableDirectory("timeReportRoot").toPath()
+    val timeReportRoot = params.getCreatableDirectory("timeReportRoot")
+
+    // Get current date information
+    val currentDate = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
+    TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+    val formatter = SimpleDateFormat("yyyy-MM-dd")
+    val thisDate = formatter.format(currentDate.getTime())
 
     // Make objects for reading, parsing, and writing json:
     val objectMapper = ObjectMapper()
     val prettyPrinter = objectMapper.writerWithDefaultPrettyPrinter()
 
-    // Mapping of users to projects to times
-    // These will be printed to the output file.
-    // {"gabbard": {"Conflict.Attack": {"seconds": 120, "formatted": "0h:2m:0s"}}}
-    val durationMap = mutableMapOf<String, MutableMap<String, Map<String, Any>>>().withDefault {
-        mutableMapOf<String, Map<String, Any>>()
-    }
+    val allProjectInfo = mutableListOf<ProjectInfo>()
 
+    // Go through each exported Inception project
     exportedAnnotationRoot.walk().filter {it.isDirectory}.forEach { projectDir ->
         val projectName = projectDir.name
-        logger.info { "ProjectName: $projectName"}
         if (projectName != exportedAnnotationRoot.name) {
-            var eventType: String? = null
-            var username: String? = null
-            if (projectName.startsWith("ACE")) {
-                // Example ACE project name: ACE-Business.Declare-Bankruptcy-gabbard
-                val acePattern = Regex(pattern = """(ACE-[a-zA-Z]*\.[a-zA-Z]*-?[a-zA-Z]*?)-(.*)""")
-                if (acePattern.containsMatchIn(projectName)) {
-                    val aceMatch = acePattern.find(projectName)
-                    eventType = aceMatch!!.groups[1]!!.value
-                    username = aceMatch.groups[2]!!.value
-                }
-            }
-            else {
-                logger.info { "Script still under construction!" }
-            }
+            val projectInfo = getProjectInfo(projectName)
+            // Each project should have a file named `event.log` - this
+            // stores the timestamps of each "event" made in the project.
             val eventLog = File(projectDir.toString(), "event.log")
-            logger.info { "logfile = $eventLog" }
-            if (eventLog.exists() && eventType != null && username != null) {
-                durationMap[username] = mutableMapOf(eventType to mapOf())
+            if (eventLog.exists() && projectInfo != null) {
+                val username = projectInfo.username
+                val eventType = projectInfo.eventType
+                logger.info { "Getting time $username spent on $eventType"}
                 // Read event.log
-                val jsonEvents = getEventsAsJson(eventLog)
-
-
-                // Get times spent in each document by running
-                // through each Inception event
-                var currentDocument: String? = null  // some events have no document field
-                var previousTime: Long = 0
-                var documentTimeElapsed: Long = 0
-                val documentTimeMap = mutableMapOf<String, Long>().withDefault { 0 }
-                for (event in jsonEvents) {
-                    val documentName = event.get("document_name")?.toString()?.removeSurrounding("\"")
-                    val annotator = event.get("annotator")?.toString()?.removeSurrounding("\"")
-                    // Only deal with events that have a "document_name" field
-                    // and involve the current annotator
-                    if (documentName != null && annotator == username) {
-                        logger.info {"On $username's $documentName"}
-                        val timestamp = event.get("created").toString().toLong()
-                        val timeSinceLastEvent = timestamp - previousTime
-                        if (previousTime == 0.toLong()) {
-                            // This is the first event in the log
-                            currentDocument = documentName
-                        }
-                        // Check if the time elapsed since the last
-                        // event makes is less than 5 minutes
-                        // (300,000 milliseconds) -
-                        // else don't add it to the
-                        // overall time spent on the document.
-                        if (timeSinceLastEvent < 300000) {
-                            documentTimeElapsed += timeSinceLastEvent
-                        }
-                        if (documentName != currentDocument) {
-                            // The user has entered a new document.
-                            // Record the time elapsed and restart the "timer"
-                            logger.info { "Total time elapsed in $currentDocument: $documentTimeElapsed" }
-                            val previousDocumentTime = documentTimeMap[currentDocument.toString()]
-                            logger.info { "Previous entry for $currentDocument: $previousDocumentTime"}
-                            if (previousDocumentTime != null) {
-                                documentTimeMap[currentDocument.toString()] = previousDocumentTime + documentTimeElapsed
-                            } else {
-                                documentTimeMap[currentDocument.toString()] = documentTimeElapsed
-                            }
-                            logger.info { "Document times now: $documentTimeMap" }
-                            documentTimeElapsed = 0
-                            currentDocument = documentName
-                        }
-                        previousTime = timestamp
-                    }
-                }
-                // All events in this Inception project have been processed.
-                // Sum up the times from each time to get the total time
-                // spent on this project.
-                logger.info { "Document times now: $documentTimeMap" }
-                val totalProjectTime = documentTimeMap.map { it.value }.sum()
-                logger.info { "Total project time: $totalProjectTime" }
-                // Convert milliseconds to a human-readable format
-                val hoursMinutesSeconds = millisecondsToHMS(totalProjectTime)
-
-                durationMap[username]!![eventType] = mapOf(
-                        "seconds" to totalProjectTime/1000, "formatted" to hoursMinutesSeconds
-                )
-
+                val jsonEvents = convertEventsToJson(eventLog)
+                // Get the total time the annotator spent on the project
+                val totalProjectTime = getTimeOnProject(jsonEvents, username)
+                projectInfo.annotationTime = totalProjectTime
+                allProjectInfo.add(projectInfo)
             } else {
-                logger.info { "No event.log for $projectName" }
+                logger.info {
+                    "Not enough project info for $projectName;" +
+                            "either event.log was not found or" +
+                            "the username/event type could not be identified."
+                 }
             }
         }
     }
-    logger.info { "Duration map: $durationMap"}
-}
-
-private fun getProjectInfo(projectName: String): Pair<String?, String?> {
-    var username: String? = null
-    var eventType: String? = null
-    if (projectName.startsWith("ACE")) {
-        // Example ACE project name: ACE-Business.Declare-Bankruptcy-gabbard
-        val acePattern = Regex(pattern = """(ACE-[a-zA-Z]*\.[a-zA-Z]*-?[a-zA-Z]*?)-(.*)""")
-        if (acePattern.containsMatchIn(projectName)) {
-            val aceMatch = acePattern.find(projectName)
-            eventType = aceMatch!!.groups[1]!!.value
-            username = aceMatch.groups[2]!!.value
-        }
+    // Write time data to output file
+    val usersToProjectTimes = mutableMapOf<String, Map<String, Map<String, Any>>>()
+    // Mapping of users to projects to times
+    // These will be printed to the output file.
+    // For now we are only outputting the times spent on each project;
+    // individual document times may be added later if there is interest.
+    // {"user_name": {"Event.Type": {"seconds": 120, "formatted": "0h:2m:0s"}}}
+    val projectsByUser = allProjectInfo.groupBy { it.username }.toSortedMap()
+    for (userItem in projectsByUser) {
+        val user = userItem.component1()
+        val userProjects = userItem.component2()
+        val projectMap = userProjects.map {
+                it.eventType to mapOf<String, Any>(
+                        "seconds" to it.annotationTime, "formatted" to it.formattedTime
+                )
+        }.toMap().toSortedMap()
+        usersToProjectTimes[user] = projectMap
     }
-    // TODO: add other filename patterns
-    return Pair(username, eventType)
+    val outfile = File(timeReportRoot, "totalAnnotationTimes-$thisDate.json")
+    outfile.writeBytes(prettyPrinter.writeValueAsBytes(usersToProjectTimes))
+    logger.info {" User annotation times written to $outfile" }
 }
 
-
-private fun getEventsAsJson(log: File): List<JsonNode> {
-    // Each line in an event.log represents an action in
-    // Inception, and these can be converted
-    // to JSON objects.
-    val eventObjectMapper = ObjectMapper()
-    val logEvents = log.readLines()
-    return logEvents.map {eventObjectMapper.readTree(it)}
+data class ProjectInfo(
+        val username: String,
+        val eventType: String,
+        var annotationTime: Long
+) {
+    val formattedTime get() = millisecondsToHMS(annotationTime)
 }
 
 private fun millisecondsToHMS(milliseconds: Long): String {
@@ -163,4 +114,96 @@ private fun millisecondsToHMS(milliseconds: Long): String {
     val millisecondsForSeconds = millisecondsForMinutes - (minutes * 60000)
     val seconds = millisecondsForSeconds/1000
     return "${hours}h:${minutes}m:${seconds}s"
+}
+
+private fun getProjectInfo(projectName: String): ProjectInfo? {
+    var username: String? = null
+    var eventType: String? = null
+    var patternMatch: MatchResult? = null
+    val projectNamePattern = if (projectName.startsWith("ACE")) {
+        // ACE project name format: ACE-Hyphenated.Event-Type-user_name
+        Regex(pattern = """(ACE-[a-zA-Z]*\.[a-zA-Z]*-?[a-zA-Z]*?)-(.*)""")
+    } else if (projectName.startsWith("CORD19")) {
+        // CORD-19 project name format:
+        // CORD19-random983letters2and40numbers-user_name
+        Regex(pattern = """(CORD19-[a-zA-Z0-9]*)-(.*)""")
+    } else {
+        // gigaword project name format:
+        // optionallanguage-Standard.EventType-user_name
+        Regex(pattern = """([a-z]*?-?.*)-(.*)""")
+    }
+    if (projectNamePattern.containsMatchIn(projectName)) {
+        patternMatch = projectNamePattern.find(projectName)
+    }
+    if (patternMatch != null) {
+        eventType = patternMatch.groups[1]!!.value
+        username = patternMatch.groups[2]!!.value
+    }
+    return if (username != null && eventType != null) {
+        ProjectInfo(username, eventType, 0)
+    } else {
+        logger.info { "Could not identify project info for $projectName" }
+        null
+    }
+}
+
+private fun convertEventsToJson(log: File): List<JsonNode> {
+    // Each line in an event.log represents an action in
+    // Inception, and these can be converted
+    // to JSON objects.
+    val eventObjectMapper = ObjectMapper()
+    val logEvents = log.readLines()
+    return logEvents.map {eventObjectMapper.readTree(it)}
+}
+
+private fun getTimeOnProject(logEvents: List<JsonNode>, username: String): Long {
+    // Get times spent in each document by running
+    // through each Inception event recorded in event.log
+    var currentDocument: String? = null  // some events have no document field
+    var previousTime: Long = 0
+    var documentTimeElapsed: Long = 0
+    val documentTimeMap = mutableMapOf<String, Long>().withDefault { 0 }
+    for (event in logEvents) {
+        val documentName = event.get("document_name")?.toString()?.removeSurrounding("\"")
+        val user = event.get("user")?.toString()?.removeSurrounding("\"")
+        // Only deal with events that have a "document_name" field
+        // and were completed by the user
+        // (admin monitoring activity also gets recorded)
+        if (documentName != null && user == username) {
+            val timestamp = event.get("created").toString().toLong()
+            val timeSinceLastEvent = timestamp - previousTime
+            if (previousTime == 0.toLong()) {
+                // This is the first event in the log
+                currentDocument = documentName
+            }
+            // If there is a relatively long gap between events,
+            // it may suggest that the annotator took a break.
+            // Check if the time elapsed since the last event
+            // is less than 5 minutes (300,000 milliseconds) -
+            // else, don't add it to the overall time spent
+            // on the document.
+            if (timeSinceLastEvent < 300000) {
+                documentTimeElapsed += timeSinceLastEvent
+            }
+            if (documentName != currentDocument) {
+                // The user has entered a new document.
+                // Record the time elapsed and "restart the timer."
+                val previousDocumentTime = documentTimeMap[currentDocument.toString()]
+                if (previousDocumentTime != null) {
+                    documentTimeMap[currentDocument.toString()] = previousDocumentTime + documentTimeElapsed
+                } else {
+                    documentTimeMap[currentDocument.toString()] = documentTimeElapsed
+                }
+                documentTimeElapsed = 0
+                currentDocument = documentName
+            }
+            // Finished with this event;
+            // prepare for the next one.
+            previousTime = timestamp
+        }
+    }
+    // All events in this Inception project have been processed.
+    // Sum up the times from each time to get the total time
+    // spent on this project.
+    return documentTimeMap.map { it.value }.sum()
 }

--- a/annotation-utils/src/main/java/edu/isi/vista/annotationutils/GetAnnotationDurations.kt
+++ b/annotation-utils/src/main/java/edu/isi/vista/annotationutils/GetAnnotationDurations.kt
@@ -107,11 +107,10 @@ data class ProjectInfo(
     val formattedTime get() = secondsToHMS(annotationTime)
 }
 
-private fun secondsToHMS(seconds: Long): String {
-    val hours = TimeUnit.SECONDS.toHours(seconds)
-    val secondsForMinutes = seconds - (hours * 3600)
-    val minutes = TimeUnit.SECONDS.toMinutes(secondsForMinutes)
-    val remainingSeconds = secondsForMinutes - (minutes * 60)
+fun secondsToHMS(seconds: Long): String {
+    val hours = seconds/3600
+    val minutes = (seconds/60)%60
+    val remainingSeconds = seconds%60
     return "${hours}h:${minutes}m:${remainingSeconds}s"
 }
 

--- a/annotation-utils/src/main/java/edu/isi/vista/annotationutils/GetAnnotationDurations.kt
+++ b/annotation-utils/src/main/java/edu/isi/vista/annotationutils/GetAnnotationDurations.kt
@@ -187,10 +187,10 @@ private fun getTimeOnProject(logEvents: List<JsonNode>, username: String): Long 
             // If there is a relatively long gap between events,
             // it may suggest that the annotator took a break.
             // Check if the time elapsed since the last event
-            // is less than 5 minutes (300,000 milliseconds) -
+            // is less than 2 minutes (120,000 milliseconds) -
             // else, don't add it to the overall time spent
             // on the document.
-            if (timeSinceLastEvent < 300000) {
+            if (timeSinceLastEvent < 120000) {
                 documentTimeElapsed += timeSinceLastEvent
             }
             if (documentName != currentDocument) {

--- a/annotation-utils/src/main/java/edu/isi/vista/annotationutils/PushAnnotations.kt
+++ b/annotation-utils/src/main/java/edu/isi/vista/annotationutils/PushAnnotations.kt
@@ -110,7 +110,12 @@ fun main(argv: Array<String>) {
     // Build params for extracting the annotation statistics
     val extractAnnotationStatsParamsBuilder = Parameters.builder()
     extractAnnotationStatsParamsBuilder.set("exportedAnnotationRoot", exportedAnnotationRoot)
-    extractAnnotationStatsParamsBuilder.set("statisticsDirectory", params.getCreatableDirectory("statisticsDirectory").absolutePath)
+    extractAnnotationStatsParamsBuilder.set(
+            "timeReportRoot", params.getCreatableDirectory("timeReportRoot").absolutePath
+    )
+    extractAnnotationStatsParamsBuilder.set(
+            "statisticsDirectory", params.getCreatableDirectory("statisticsDirectory").absolutePath
+    )
     val extractAnnotationStatsParams = extractAnnotationStatsParamsBuilder.build()
 
     setUpRepository(localWorkingCopyDirectory, repoToPushTo).use { git ->

--- a/annotation-utils/src/main/java/edu/isi/vista/annotationutils/RunExportAnnotations.kt
+++ b/annotation-utils/src/main/java/edu/isi/vista/annotationutils/RunExportAnnotations.kt
@@ -1,0 +1,19 @@
+package edu.isi.vista.annotationutils
+
+import edu.isi.nlp.parameters.serifstyle.SerifStyleParameterFileLoader
+import java.io.File
+
+/**
+ * Script for running ExportAnnotations independently
+ */
+
+fun main(argv: Array<String>) {
+    if (argv.size != 1) {
+        throw RuntimeException("Expected a single argument: a parameter file")
+    }
+    val paramsLoader = SerifStyleParameterFileLoader.Builder()
+            .interpolateEnvironmentalVariables(true).build()
+    val params = paramsLoader.load(File(argv[0]))
+
+    ExportAnnotations.export(params)
+}

--- a/annotation-utils/src/main/java/edu/isi/vista/annotationutils/RunExtractAnnotationStats.kt
+++ b/annotation-utils/src/main/java/edu/isi/vista/annotationutils/RunExtractAnnotationStats.kt
@@ -1,0 +1,23 @@
+package edu.isi.vista.annotationutils
+
+import edu.isi.nlp.parameters.Parameters
+import edu.isi.nlp.parameters.serifstyle.SerifStyleParameterFileLoader
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.jsoup.nodes.Element
+import org.jsoup.select.Elements
+import java.io.File
+
+/**
+ * Script for running ExtractAnnotationStats independently
+ */
+
+fun main(argv: Array<String>) {
+    if (argv.size != 1) {
+        throw RuntimeException("Expected a single argument: a parameter file")
+    }
+    val paramsLoader = SerifStyleParameterFileLoader.Builder().build()
+    val params = paramsLoader.load(File(argv[0]))
+
+    ExtractAnnotationStats.extractStats(params)
+}

--- a/annotation-utils/src/main/java/edu/isi/vista/annotationutils/RunGetAnnotationDurations.kt
+++ b/annotation-utils/src/main/java/edu/isi/vista/annotationutils/RunGetAnnotationDurations.kt
@@ -1,0 +1,18 @@
+package edu.isi.vista.annotationutils
+
+import edu.isi.nlp.parameters.serifstyle.SerifStyleParameterFileLoader
+import java.io.File
+
+/**
+ * Script for running GetAnnotationDurations independently
+ */
+
+fun main(argv: Array<String>) {
+    if (argv.size != 1) {
+        throw RuntimeException("Expected a single argument: a parameter file")
+    }
+    val paramsLoader = SerifStyleParameterFileLoader.Builder().build()
+    val params = paramsLoader.load(File(argv[0]))
+
+    GetAnnotationDurations.getDurations(params)
+}

--- a/sample_params/extract_annotation_stats.params
+++ b/sample_params/extract_annotation_stats.params
@@ -1,2 +1,3 @@
 exportedAnnotationRoot: /Users/isiboston/Documents/projects/gaia/curatedTraining/repos/curated-training-annotation/data/exported
+timeReportRoot: /Users/isiboston/Documents/projects/gaia/curatedTraining/repos/curated-training-annotation/data/timeReports
 statisticsDirectory: /Users/isiboston/Documents/projects/gaia/curatedTraining/repos/curated-training-annotation/data/annotation-statistics

--- a/sample_params/get_annotation_durations.params
+++ b/sample_params/get_annotation_durations.params
@@ -1,2 +1,2 @@
 exportedAnnotationRoot: /Users/isiboston/Documents/projects/gaia/curatedTraining/data/exported_time_test
-durationOutputRoot: /Users/isiboston/Documents/projects/gaia/curatedTraining/data/durations_time_test
+timeReportRoot: /Users/isiboston/Documents/projects/gaia/curatedTraining/data/durations_time_test

--- a/sample_params/get_annotation_durations.params
+++ b/sample_params/get_annotation_durations.params
@@ -1,0 +1,2 @@
+exportedAnnotationRoot: /Users/isiboston/Documents/projects/gaia/curatedTraining/data/exported_time_test
+durationOutputRoot: /Users/isiboston/Documents/projects/gaia/curatedTraining/data/durations_time_test

--- a/sample_params/push_annotations.lee.params
+++ b/sample_params/push_annotations.lee.params
@@ -10,6 +10,7 @@ gigawordDataDirectory: /Users/isiboston/Documents/LDC/giga/gigaword_eng_5/data/
 indexDirectory: /Users/isiboston/Documents/LDC/giga/indices/
 restoredJsonDirectory: /Users/isiboston/Documents/projects/gaia/curatedTraining/data/restored
 
+timeReportRoot: /Users/isiboston/Documents/projects/gaia/curatedTraining/repos/curated-training-vistanlp/data/timeReports
 statisticsDirectory: /Users/isiboston/Documents/projects/gaia/curatedTraining/repos/curated-training-vistanlp/data/annotation-statistics
 
 annotatedFlexNLPOutputDir: /Users/isiboston/Documents/projects/gaia/curatedTraining/repos/curated-training-vistanlp/data/flexnlp_pickled


### PR DESCRIPTION
Closes #73 

Main file: `GetAnnotationDurations.kt`

* Uses a project's `event.log` to estimate how long the user spent annotating on that project
* `ExportAnnotations` now saves each project's `event.log`
* `ExtractAnnotationStats` prints the resulting annotation times to stats reports
* Collecting the times will be part of the nightly export routine