### PR TITLE
Add positive and negative sentence counts by user and event type

### DIFF
--- a/annotation-utils/src/main/java/edu/isi/vista/annotationutils/ExtractAnnotationStats.kt
+++ b/annotation-utils/src/main/java/edu/isi/vista/annotationutils/ExtractAnnotationStats.kt
@@ -561,17 +561,21 @@ class ExtractAnnotationStats {
                                     td { +"${annotationDiffs.byUser[user]}" }
                                 }
                                 if (annotationTimes != null && totalUserSentences != null) {
-                                    var totalUserSeconds = 0.toFloat()
-                                    for (projectInfo in annotationTimes[user].fields()) {
-                                        val project = projectInfo.key
-                                        // Skip ACE projects since they are quicker to finish than
-                                        // regular tasks
-                                        if (!project.contains("ACE-")) {
-                                            totalUserSeconds += annotationTimes[user][project]["seconds"]
-                                                    .toString().toFloat()
+                                    if (annotationTimes[user] != null) {
+                                        var totalUserSeconds = 0.toFloat()
+                                        for (projectInfo in annotationTimes[user].fields()) {
+                                            val project = projectInfo.key
+                                            // Skip ACE projects since they are quicker to finish than
+                                            // regular tasks
+                                            if (!project.contains("ACE-")) {
+                                                totalUserSeconds += annotationTimes[user][project]["seconds"]
+                                                        .toString().toFloat()
+                                            }
                                         }
+                                        td { +getSentencesPerHour(totalUserSentences, totalUserSeconds) }
+                                    } else {
+                                        td { +"n/a" }
                                     }
-                                    td { +getSentencesPerHour(totalUserSentences, totalUserSeconds) }
                                 } else {
                                     td { +"n/a" }
                                 }

--- a/annotation-utils/src/main/java/edu/isi/vista/annotationutils/ExtractAnnotationStats.kt
+++ b/annotation-utils/src/main/java/edu/isi/vista/annotationutils/ExtractAnnotationStats.kt
@@ -537,14 +537,22 @@ class ExtractAnnotationStats {
                         tr {
                             th {+"User"}
                             th {+"Total sentences"}
+                            th {+"Positive"}
+                            th {+"Negative"}
                             th {+"New sentences"}
                             th {+"Avg. sentences/hour"}
                         }
+                        val sentencesByUser = allSentences.groupBy { it.user }
                         for (user in newAnnotationStats.byUser.keys) {
                             val totalUserSentences = newAnnotationStats.byUser[user]
+                            val userPositiveNegativeCounts = (
+                                    sentencesByUser[user] ?: error("")
+                                    ).countBy { it.negativeExample }
                             tr {
                                 td { +user }
                                 td { +"$totalUserSentences" }
+                                td {+"${userPositiveNegativeCounts[false] ?: 0}"}
+                                td {+"${userPositiveNegativeCounts[true] ?: 0}"}
                                 if (annotationDiffs == null) {
                                     td { +"n/a" }
                                 } else if (annotationDiffs.byUser[user] == null) {
@@ -575,12 +583,20 @@ class ExtractAnnotationStats {
                         tr {
                             th {+"Event type"}
                             th {+"Total sentences"}
+                            th {+"Positive"}
+                            th {+"Negative"}
                             th {+"New sentences"}
                         }
+                        val sentencesByEventType = allSentences.groupBy { it.eventType }
                         for (eventType in newAnnotationStats.byEventType.keys) {
+                            val eventTypePositiveNegativeCounts = (
+                                    sentencesByEventType[eventType] ?: error("")
+                                    ).countBy { it.negativeExample }
                             tr {
-                                td {+"$eventType" }
+                                td {+eventType}
                                 td {+"${newAnnotationStats.byEventType[eventType]}"}
+                                td {+"${eventTypePositiveNegativeCounts[false] ?: 0}"}
+                                td {+"${eventTypePositiveNegativeCounts[true] ?: 0}"}
                                 if (annotationDiffs == null) {
                                     td {+"n/a"}
                                 }


### PR DESCRIPTION
Closes #79 
Example of the new output:
<img width="823" alt="Screen Shot 2020-06-29 at 6 20 30 PM" src="https://user-images.githubusercontent.com/15387865/86062593-0e0e3080-ba37-11ea-9acc-c533929de13e.png">
