### PR TITLE
86 missing or unnecessary annotation times

### DIFF
--- a/annotation-utils/src/main/java/edu/isi/vista/annotationutils/ParseEventLogs.kt
+++ b/annotation-utils/src/main/java/edu/isi/vista/annotationutils/ParseEventLogs.kt
@@ -37,6 +37,8 @@ import java.util.*
  *
  */
 
+val bannedStrings = listOf("copy_of", "sandbox", "test")
+
 class ParseEventLogs {
     companion object {
         fun main(argv: Array<String>) {
@@ -46,6 +48,7 @@ class ParseEventLogs {
             // Load parameters
             val paramsLoader = SerifStyleParameterFileLoader.Builder().build()
             val params = paramsLoader.load(File(argv[0]))
+            parseEventLogs(params)
         }
         fun parseEventLogs(params: edu.isi.nlp.parameters.Parameters) {
             val exportedAnnotationRoot = params.getExistingDirectory("exportedAnnotationRoot")
@@ -71,7 +74,7 @@ class ParseEventLogs {
                 // Each project should have a file named `event.log` - this
                 // stores the timestamps of each "event" made in the project.
                 val eventLog = File(projectDir.toString(), EVENT_LOG)
-                if (eventLog.exists() && projectInfo != null) {
+                if (eventLog.exists() && projectInfo != null && !bannedStrings.any { projectName.contains(it) }) {
                     val username = projectInfo.username
                     val eventType = projectInfo.eventType
                     logger.info { "Getting time $username spent on $eventType"}

--- a/annotation-utils/src/main/java/edu/isi/vista/annotationutils/ParseEventLogs.kt
+++ b/annotation-utils/src/main/java/edu/isi/vista/annotationutils/ParseEventLogs.kt
@@ -218,12 +218,7 @@ private fun parseProjectEvents(logEvents: List<JsonNode>, username: String): Pai
             if (documentName != currentDocument) {
                 // The user has entered a new document.
                 // Record the time elapsed and "restart the timer."
-                val previousDocumentTime = documentTimeMap[currentDocument.toString()]
-                if (previousDocumentTime != null) {
-                    documentTimeMap[currentDocument.toString()] = previousDocumentTime + documentTimeElapsed
-                } else {
-                    documentTimeMap[currentDocument.toString()] = documentTimeElapsed
-                }
+                updateDocumentTimeMap(documentTimeMap, documentTimeElapsed, currentDocument.toString())
                 documentTimeElapsed = 0
                 currentDocument = documentName
             }
@@ -233,7 +228,23 @@ private fun parseProjectEvents(logEvents: List<JsonNode>, username: String): Pai
         }
     }
     // All events in this Inception project have been processed.
+    // Record the elapsed time for the last document.
+    updateDocumentTimeMap(documentTimeMap, documentTimeElapsed, currentDocument.toString())
     // Sum up the times from each document to get the total time
     // spent on this project.
     return Pair<Long, Set<String>>(documentTimeMap.map { it.value }.sum()/1000, indicatorSet)
 }
+
+private fun updateDocumentTimeMap(
+        documentTimeMap: MutableMap<String, Long>,
+        timeElapsed: Long,
+        document: String
+) {
+    val previousDocumentTime = documentTimeMap[document]
+    if (previousDocumentTime != null) {
+        documentTimeMap[document] = previousDocumentTime + timeElapsed
+    } else {
+        documentTimeMap[document] = timeElapsed
+    }
+}
+


### PR DESCRIPTION
Addresses issues listed in #86 by

1. Extending the read timeout for the export so that log files from larger projects can be downloaded
2. Ensuring that the time elapsed on the last annotated document is recorded
3. Preventing `copy_of` and `sandbox` projects from being processed