### PR TITLE
Fix modified copy generation

### DIFF
--- a/annotation-utils/src/main/java/edu/isi/vista/annotationutils/AddNewTags.kt
+++ b/annotation-utils/src/main/java/edu/isi/vista/annotationutils/AddNewTags.kt
@@ -171,7 +171,7 @@ fun main(argv: Array<String>) {
                         )
                 )
                 for (projectFile in it) {
-                    val inMemoryProjectPath = inMemoryFileSystem.getPath("/${projectFile.name}")
+                    val inMemoryProjectPath = inMemoryFileSystem.getPath(projectFile.name)
                     val projectBytes = it.getInputStream(projectFile.name)?.readBytes()
                     if (projectBytes != null) {
                         if (inMemoryProjectPath.count() > 1) {
@@ -186,7 +186,7 @@ fun main(argv: Array<String>) {
                         val jsonBytes = it.getInputStream(projectFile.name)?.readBytes()
                         if (jsonBytes != null) {
                             Files.delete(inMemoryProjectPath)
-                            val inMemoryJson = inMemoryFileSystem.getPath("/${projectFile.name}")
+                            val inMemoryJson = inMemoryFileSystem.getPath(projectFile.name)
                             val jsonTree = objectMapper.readTree(jsonBytes)
                             val arguments = eventTypesToNewTags[project.value]
                             replaceProject = addArgumentsToJson(jsonTree, project.key.name, arguments)


### PR DESCRIPTION
Makes a fix to `AddNewTags` - a bug identified while discussing [this issue](https://github.com/isi-vista/curated-training-annotator/issues/91) turns out to be the cause of the overwritten event logs.