### PR TITLE
36 allow configuring restoration via parameters

### DIFF
--- a/annotation-utils/src/main/java/edu/isi/vista/annotationutils/PushAnnotations.kt
+++ b/annotation-utils/src/main/java/edu/isi/vista/annotationutils/PushAnnotations.kt
@@ -128,14 +128,32 @@ fun main(argv: Array<String>) {
     // Build params for restoring the original text
     val restoreJson = params.getOptionalBoolean("restoreJson").or(false)
     val restoreJsonParams = if (restoreJson) {
-        Parameters.builder()
+        val restoreJsonParamsBuilder = Parameters.builder()
                 .set("indexDirectory", params.getExistingDirectory("indexDirectory").absolutePath)
-                .set("aceEngDataDirectory", params.getExistingDirectory("aceEngDataDirectory").absolutePath)
-                .set("cord19DataDirectory", params.getExistingDirectory("cord19DataDirectory").absolutePath)
                 .set("gigawordDataDirectory", params.getExistingDirectory("gigawordDataDirectory").absolutePath)
                 .set("inputJsonDirectory", exportedAnnotationRoot)
                 .set("restoredJsonDirectory", params.getCreatableDirectory("restoredJsonDirectory").absolutePath)
-                .build()
+        if (params.getOptionalBoolean("restoreAce").or(params.isPresent("aceEngDataDirectory"))) {
+            restoreJsonParamsBuilder.set(
+                    "aceEngDataDirectory", params.getExistingDirectory("aceEngDataDirectory").absolutePath
+            )
+        }
+        if (params.getOptionalBoolean("restoreCord19").or(params.isPresent("cord19DataDirectory"))) {
+            restoreJsonParamsBuilder.set(
+                    "cord19DataDirectory", params.getExistingDirectory("cord19DataDirectory").absolutePath
+            )
+        }
+        if (params.getOptionalBoolean("restoreRussian").or(params.isPresent("russianDataDirectory"))) {
+            restoreJsonParamsBuilder.set(
+                    "russianDataDirectory", params.getExistingDirectory("russianDataDirectory").absolutePath
+            )
+        }
+        if (params.getOptionalBoolean("restoreSpanish").or(params.isPresent("spanishDataDirectory"))) {
+            restoreJsonParamsBuilder.set(
+                    "spanishDataDirectory", params.getExistingDirectory("spanishDataDirectory").absolutePath
+            ).set("spanishIndexDirectory", params.getExistingDirectory("spanishIndexDirectory").absolutePath)
+        }
+        restoreJsonParamsBuilder.build()
     } else {
         null
     }

--- a/annotation-utils/src/main/java/edu/isi/vista/annotationutils/RestoreJson.kt
+++ b/annotation-utils/src/main/java/edu/isi/vista/annotationutils/RestoreJson.kt
@@ -251,7 +251,7 @@ private fun getRussianDocID(filename: String): String? {
     // Returns null if not a Russian filename
     // Russian filenames consist of a string of letters and numbers
     // starting with "RUS_"
-    // Example: RUS_DF_579382_839572091_P861983UGN-john_bob.json
+    // Example: RUS_DF_579382_08212053_P861983UGN-john_bob.json
 
     val regex = Regex(pattern = """(RUS_[A-Z]{2}_[A-Z0-9]{6}_[A-Z0-9]{8}_[A-Z0-9]{9})-.*""")
     if (regex.containsMatchIn(filename)) {

--- a/annotation-utils/src/main/java/edu/isi/vista/annotationutils/RestoreJson.kt
+++ b/annotation-utils/src/main/java/edu/isi/vista/annotationutils/RestoreJson.kt
@@ -96,7 +96,6 @@ class RestoreJson {
             inputJsonDirectory.walk().filter { it.isFile }.forEach { jsonFile ->
                 val filename = jsonFile.name
                 val englishPattern = Regex("[\b_]ENG[\b_]")
-                val russianPattern = Regex("RUS[\b_]")
                 val spanishPattern = Regex("[\b_]SPA[\b_]")
                 //returns docID if ace file, else returns null
                 val aceDocID = getAceDocID(filename)
@@ -150,7 +149,7 @@ class RestoreJson {
                         logger.info { "Restored $filename" }
                     } else {
                         logger.info {
-                            "Skipping $filename because you indicated not to restore documents of this type."
+                            "Skipping $filename"
                         }
                     }
                 } else {
@@ -193,7 +192,7 @@ fun makeTextSource(params: Parameters, corpusName: String): OriginalTextSource {
         return RussianCorpusTextSource(params.getExistingDirectory("russianDataDirectory"))
     }
     else {
-        throw IOException("A corpus: " + corpusName + " does not exist.");
+        throw IOException("A corpus: $corpusName does not exist.");
     }
 }
 
@@ -202,7 +201,7 @@ fun docIDToFilename(symbol: Symbol?): String {
         throw RuntimeException("Got null symbol")
     }
     // e.g. AFP_ENG_19960918.0012 -> afp_eng/afp_eng_199609
-    val st = symbol?.asString()?.toLowerCase()
+    val st = symbol.asString()?.toLowerCase()
     val dir = st?.substring(0, 7) //
     val basename = st?.substring(0, 14)
     return Paths.get(dir, basename).toString()
@@ -254,7 +253,7 @@ private fun getRussianDocID(filename: String): String? {
     // starting with "RUS_"
     // Example: RUS_DF_579382_839572091_P861983UGN-john_bob.json
 
-    val regex = Regex(pattern = """(RUS_[A-Z]{2}_[A-Z0-9]{6}_[A-Z0-9]{8,}_[A-Z0-9]{9})-.*""")
+    val regex = Regex(pattern = """(RUS_[A-Z]{2}_[A-Z0-9]{6}_[A-Z0-9]{8}_[A-Z0-9]{9})-.*""")
     if (regex.containsMatchIn(filename)) {
         val matchResult = regex.find(filename)
         //Returns only the doc id. In this case: CNNHL_ENG_20030304_142751.10

--- a/annotation-utils/src/main/java/edu/isi/vista/annotationutils/RestoreJson.kt
+++ b/annotation-utils/src/main/java/edu/isi/vista/annotationutils/RestoreJson.kt
@@ -255,10 +255,16 @@ private fun getRussianDocID(filename: String): String? {
 
     val regex = Regex(pattern = """(RUS_[A-Z]{2}_[A-Z0-9]{6}_[A-Z0-9]{8}_[A-Z0-9]{9})-.*""")
     if (regex.containsMatchIn(filename)) {
-        val matchResult = regex.find(filename)
-        //Returns only the doc id. In this case: CNNHL_ENG_20030304_142751.10
-        val matchGroups = matchResult!!.groups
-        // match groups = ("<docid>-john_bob.json", "<docid>")
+        // The section of the above pattern in parentheses is the "capturing group";
+        // in this case it is the pattern of the document ID,
+        // since this is the information we want to return.
+        // If the pattern is found in the filename, it will fetch
+        // the filename and the capturing group
+        // and assign them as `groups` of matchResult.
+        val matchResult: MatchResult? = regex.find(filename)
+        val matchGroups: MatchGroupCollection = matchResult!!.groups
+        // match groups = ("RUS_DF_579382_08212053_P861983UGN-john_bob.json", "RUS_DF_579382_08212053_P861983UGN")
+        // The capturing group match is the second item.
         return matchGroups[1]!!.value
     }
     return null

--- a/annotation-utils/src/main/java/edu/isi/vista/annotationutils/RussianCorpusTextSource.java
+++ b/annotation-utils/src/main/java/edu/isi/vista/annotationutils/RussianCorpusTextSource.java
@@ -24,7 +24,9 @@ public final class RussianCorpusTextSource implements OriginalTextSource{
     public Optional<String> getOriginalText(final Symbol docID) throws IOException {
         Optional<CharSource> russianCharSource = Optional.absent();
         // Search and find file in unzipped/ltf/
-        File sourceDocFile = new File(russianDataDirectory, docID.toString() + ".ltf.xml");
+        File sourceDocFile = new File(
+                russianDataDirectory + "/data/monolingual_text/unzipped/ltf/" + docID.toString() + ".ltf.xml"
+        );
         if(sourceDocFile.exists()) {
             russianCharSource =
                     Optional.of(Files.asCharSource(sourceDocFile, Charsets.UTF_8));

--- a/annotation-utils/src/main/java/edu/isi/vista/annotationutils/RussianCorpusTextSource.java
+++ b/annotation-utils/src/main/java/edu/isi/vista/annotationutils/RussianCorpusTextSource.java
@@ -1,0 +1,62 @@
+package edu.isi.vista.annotationutils;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.CharSource;
+import com.google.common.io.Files;
+import edu.isi.nlp.corpora.LctlText;
+import edu.isi.nlp.corpora.LtfDocument;
+import edu.isi.nlp.corpora.LtfReader;
+import edu.isi.nlp.symbols.Symbol;
+import com.google.common.base.Optional;
+import edu.isi.nlp.io.OriginalTextSource;
+import java.io.File;
+import java.lang.reflect.Array;
+import java.nio.file.Path;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Arrays;
+
+
+public final class RussianCorpusTextSource implements OriginalTextSource{
+    private  File russianDataDirectory;
+
+    public Optional<String> getOriginalText(final Symbol docID) throws IOException {
+        Optional<CharSource> russianCharSource = Optional.absent();
+        // Search and find file in unzipped/ltf/
+        File sourceDocFile = new File(russianDataDirectory, docID.toString() + ".ltf.xml");
+        if(sourceDocFile.exists()) {
+            russianCharSource =
+                    Optional.of(Files.asCharSource(sourceDocFile, Charsets.UTF_8));
+        }
+        if(!russianCharSource.isPresent()) {
+            throw new IOException("Source file is empty for document: " + docID.toString());
+        }
+        return Optional.of(processRussianSourceText(russianCharSource.get()));
+    }
+
+    RussianCorpusTextSource(File russianDataDirectory) throws IOException{
+        if(!russianDataDirectory.exists()) {
+            throw new IOException("The russianDataDirectory does not exist");
+        }
+        if(!russianDataDirectory.isDirectory()) {
+            throw new IOException("The russianDataDirectory parameter given is not a directory");
+        }
+        this.russianDataDirectory = russianDataDirectory;
+    }
+
+    private String processRussianSourceText (CharSource russianCharSource) {
+        // In theory there could be multiple documents within a single .ltf.xml file,
+        // so for now we are stringing together the original text
+        // of each document - even if there is only ever one - in the corpus file.
+        LtfReader reader = new LtfReader();
+        List<String> originalTextItems = new ArrayList<>();
+        LctlText lctlText = reader.read(russianCharSource);
+        List<LtfDocument> ltfDocuments = lctlText.getDocuments();
+        for (LtfDocument ltfDocument : ltfDocuments) {
+            originalTextItems.add(ltfDocument.getOriginalText().content().toString());
+        }
+        return String.join("\n", originalTextItems);
+    }
+}
+

--- a/sample_params/push_annotations.lee.params
+++ b/sample_params/push_annotations.lee.params
@@ -8,8 +8,12 @@ zipExportRoot: /Users/isiboston/Documents/projects/gaia/curatedTraining/repos/cu
 
 restoreJson: false
 aceEngDataDirectory: /Users/isiboston/Documents/projects/gaia/curatedTraining/corpora/ace_2005_td_v7_LDC2006T06/data/English
+cord19DataDirectory: /Users/isiboston/Documents/projects/gaia/curatedTraining/corpora/2020-03-13
 gigawordDataDirectory: /Users/isiboston/Documents/LDC/giga/gigaword_eng_5/data/
 indexDirectory: /Users/isiboston/Documents/LDC/giga/indices/
+russianDataDirectory: /Users/isiboston/Documents/LDC/ltf/LDC2016E94_LORELEI_Russian_Representative_Language_Pack_Monolingual_Text_V1
+spanishDataDirectory: /Users/isiboston/Documents/LDC/giga/spa_gw_3/data/
+spanishIndexDirectory: /Users/isiboston/Documents/LDC/giga/indices/spa/
 restoredJsonDirectory: /Users/isiboston/Documents/projects/gaia/curatedTraining/data/restored
 
 originalLogsRoot: /Users/isiboston/Documents/projects/gaia/curatedTraining/repos/curated-training-vistanlp/data/original-logs

--- a/sample_params/restore-text.params
+++ b/sample_params/restore-text.params
@@ -1,7 +1,7 @@
 aceEngDataDirectory:
 cord19DataDirectory:
 gigawordDataDirectory: /Users/admin/giga/gigaword_eng_5/data/
-russianDataDirectory: /Users/admin/corpora/LDC2016E94_LORELEI_Russian_Representative_Language_Pack_Monolingual_Text_V1/data/monolingual_text/unzipped/ltf/
+russianDataDirectory: /Users/admin/corpora/LDC2016E94_LORELEI_Russian_Representative_Language_Pack_Monolingual_Text_V1/
 spanishDataDirectory: /Users/admin/spa_gw_3/data/
 indexDirectory: /Users/admin/giga/indices/eng/
 spanishIndexDirectory: /Users/admin/giga/indices/spa/

--- a/sample_params/restore-text.params
+++ b/sample_params/restore-text.params
@@ -1,6 +1,8 @@
 aceEngDataDirectory:
 cord19DataDirectory:
 gigawordDataDirectory: /Users/admin/giga/gigaword_eng_5/data/
-indexDirectory: /Users/admin/giga/indices/
+spanishDataDirectory: /Users/admin/spa_gw_3/data/
+indexDirectory: /Users/admin/giga/indices/eng/
+spanishIndexDirectory: /Users/admin/giga/indices/spa/
 inputJsonDirectory: /Users/admin/giga/export/
 restoredJsonDirectory: /Users/admin/giga/restored/

--- a/sample_params/restore-text.params
+++ b/sample_params/restore-text.params
@@ -1,6 +1,7 @@
 aceEngDataDirectory:
 cord19DataDirectory:
 gigawordDataDirectory: /Users/admin/giga/gigaword_eng_5/data/
+russianDataDirectory: /Users/admin/corpora/LDC2016E94_LORELEI_Russian_Representative_Language_Pack_Monolingual_Text_V1/data/monolingual_text/unzipped/ltf/
 spanishDataDirectory: /Users/admin/spa_gw_3/data/
 indexDirectory: /Users/admin/giga/indices/eng/
 spanishIndexDirectory: /Users/admin/giga/indices/spa/


### PR DESCRIPTION
Closes #36 

* Allows optional restoration of non-English-Gigaword text
* Enables restoration of Spanish and Russian document text

The ingestion of Spanish and Russian documents after this relies on https://github.com/isi-vista/gaia-event-extraction/pull/195