### PR TITLE
Optionally parse logs from archive directory

### DIFF
--- a/annotation-utils/src/main/java/edu/isi/vista/annotationutils/PushAnnotations.kt
+++ b/annotation-utils/src/main/java/edu/isi/vista/annotationutils/PushAnnotations.kt
@@ -110,6 +110,11 @@ fun main(argv: Array<String>) {
     // Build params for extracting the annotation statistics
     val extractAnnotationStatsParamsBuilder = Parameters.builder()
     extractAnnotationStatsParamsBuilder.set("exportedAnnotationRoot", exportedAnnotationRoot)
+    if (params.isPresent("originalLogsRoot")) {
+        extractAnnotationStatsParamsBuilder.set(
+                "originalLogsRoot", params.getExistingDirectory("originalLogsRoot").absolutePath
+        )
+    }
     extractAnnotationStatsParamsBuilder.set(
             "indicatorSearchesRoot", params.getCreatableDirectory("indicatorSearchesRoot").absolutePath
     )

--- a/sample_params/extract_annotation_stats.params
+++ b/sample_params/extract_annotation_stats.params
@@ -1,4 +1,5 @@
 exportedAnnotationRoot: /Users/isiboston/Documents/projects/gaia/curatedTraining/repos/curated-training-annotation/data/exported
+originalLogsRoot: /Users/isiboston/Documents/projects/gaia/curatedTraining/repos/curated-training-annotation/data/original-logs
 indicatorSearchesRoot: /Users/isiboston/Documents/projects/gaia/curatedTraining/repos/curated-training-annotation/data/indicator-searches
-timeReportRoot: /Users/isiboston/Documents/projects/gaia/curatedTraining/repos/curated-training-annotation/data/timeReports
+timeReportRoot: /Users/isiboston/Documents/projects/gaia/curatedTraining/repos/curated-training-annotation/data/time-reports
 statisticsDirectory: /Users/isiboston/Documents/projects/gaia/curatedTraining/repos/curated-training-annotation/data/annotation-statistics

--- a/sample_params/parse_event_logs.params
+++ b/sample_params/parse_event_logs.params
@@ -1,3 +1,4 @@
 exportedAnnotationRoot: /Users/isiboston/Documents/projects/gaia/curatedTraining/data/exported
+originalLogsRoot: /Users/isiboston/Documents/projects/gaia/curatedTraining/data/original-logs
 indicatorSearchesRoot: /Users/isiboston/Documents/projects/gaia/curatedTraining/data/indicator-searches
 timeReportRoot: /Users/isiboston/Documents/projects/gaia/curatedTraining/data/time-reports

--- a/sample_params/push_annotations.lee.params
+++ b/sample_params/push_annotations.lee.params
@@ -10,6 +10,7 @@ gigawordDataDirectory: /Users/isiboston/Documents/LDC/giga/gigaword_eng_5/data/
 indexDirectory: /Users/isiboston/Documents/LDC/giga/indices/
 restoredJsonDirectory: /Users/isiboston/Documents/projects/gaia/curatedTraining/data/restored
 
+originalLogsRoot: /Users/isiboston/Documents/projects/gaia/curatedTraining/repos/curated-training-vistanlp/data/original-logs
 indicatorSearchesRoot: /Users/isiboston/Documents/projects/gaia/curatedTraining/repos/curated-training-vistanlp/data/indicator-searches
 timeReportRoot: /Users/isiboston/Documents/projects/gaia/curatedTraining/repos/curated-training-vistanlp/data/timeReports
 statisticsDirectory: /Users/isiboston/Documents/projects/gaia/curatedTraining/repos/curated-training-vistanlp/data/annotation-statistics


### PR DESCRIPTION
Closes #91 
`ParseEventLogs` can now take a directory path as input from which it can parse supplementary log files and combine their statistics with those of the main logs.