### PR TITLE
100 adjustments to accommodate username mapping

### DIFF
--- a/annotation-utils/src/main/java/edu/isi/vista/annotationutils/ExportAnnotations.kt
+++ b/annotation-utils/src/main/java/edu/isi/vista/annotationutils/ExportAnnotations.kt
@@ -117,8 +117,11 @@ class ExportAnnotations {
                 }
 
                 // Get the modified user/project names and use them to write the output file paths.
-                // These names will not change if usernamesToAbbreviations is not found
+                // These names will not change if usernameJson is not found
                 // or if a given username has no entry in the mapping.
+
+                // The value of project.name should have format
+                // optionalPrefix-Event.Type-user_name
                 val userSeparatorIndex = project.name.lastIndexOf("-")
                 val projectUsername = if (userSeparatorIndex >= 0)
                     project.name.substring(userSeparatorIndex + 1, project.name.length) else null

--- a/annotation-utils/src/main/java/edu/isi/vista/annotationutils/ExportAnnotations.kt
+++ b/annotation-utils/src/main/java/edu/isi/vista/annotationutils/ExportAnnotations.kt
@@ -226,13 +226,14 @@ class ExportAnnotations {
 
                             val jsonBytes = it.getInputStream("$zipEntryName.json")?.readBytes()
                             if (jsonBytes != null) {
-                                // Note that output file paths are unique because they include the project name, the document
-                                // id, and the annotator name. Each annotator can only annotate a document once in a project.
                                 val documentUsername = usernameMap.get(annotationRecord.user)
                                         ?.toString()?.removeSurrounding("\"")
                                 // Skip documents where the annotator (usually an admin user)
                                 // is not the project's annotator.
                                 if (documentUsername == outputUsername) {
+                                    // Note that output file paths are unique because they include the project name,
+                                    // the document id, and the annotator name. Each annotator can only annotate
+                                    // a document once in a project.
                                     val outFileName = projectOutputDir.resolve(
                                             "${document.name}-$documentUsername.json"
                                     )

--- a/annotation-utils/src/main/java/edu/isi/vista/annotationutils/ParseEventLogs.kt
+++ b/annotation-utils/src/main/java/edu/isi/vista/annotationutils/ParseEventLogs.kt
@@ -133,7 +133,9 @@ class ParseEventLogs {
                 val projectsToIndicatorListsMap = mutableMapOf<String, MutableSet<String>>()
                         .withDefault { mutableSetOf() }
                 for (pair in projectsToIndicatorLists) {
-                    projectsToIndicatorListsMap.getValue(pair.first).union(pair.second)
+                    val indicatorListsUnion: MutableSet<String> = projectsToIndicatorListsMap
+                            .getValue(pair.first).union(pair.second).toMutableSet()
+                    projectsToIndicatorListsMap[pair.first] = indicatorListsUnion
                 }
                 val projectsToIndicatorListsSortedMap = projectsToIndicatorListsMap.toMap().toSortedMap()
                 val projectsToTimes = userProjects.map {

--- a/annotation-utils/src/main/java/edu/isi/vista/annotationutils/PushAnnotations.kt
+++ b/annotation-utils/src/main/java/edu/isi/vista/annotationutils/PushAnnotations.kt
@@ -89,6 +89,7 @@ fun main(argv: Array<String>) {
 
     val exportedAnnotationRoot = params.getCreatableDirectory("exportedAnnotationRoot").absolutePath
     val usernameJson = params.getOptionalExistingFile("usernameJson").orNull()
+    val hasUsernameJson = usernameJson != null
 
     // Build params for exporting the annotations
     val exportAnnotationsParamsBuilder = Parameters.builder()
@@ -118,7 +119,7 @@ fun main(argv: Array<String>) {
     // Build params for extracting the annotation statistics
     val extractAnnotationStatsParamsBuilder = Parameters.builder()
     extractAnnotationStatsParamsBuilder.set("exportedAnnotationRoot", exportedAnnotationRoot)
-    if (params.isPresent("originalLogsRoot")) {
+    if (hasUsernameJson) {
         extractAnnotationStatsParamsBuilder.set(
                 "originalLogsRoot", params.getExistingDirectory("originalLogsRoot").absolutePath
         )
@@ -129,7 +130,9 @@ fun main(argv: Array<String>) {
     extractAnnotationStatsParamsBuilder.set(
             "timeReportRoot", params.getCreatableDirectory("timeReportRoot").absolutePath
     )
-    extractAnnotationStatsParamsBuilder.set("usernameJson", usernameJson!!.absolutePath)
+    if (hasUsernameJson) {
+        extractAnnotationStatsParamsBuilder.set("usernameJson", usernameJson!!.absolutePath)
+    }
     extractAnnotationStatsParamsBuilder.set(
             "statisticsDirectory", params.getCreatableDirectory("statisticsDirectory").absolutePath
     )

--- a/annotation-utils/src/main/java/edu/isi/vista/annotationutils/PushAnnotations.kt
+++ b/annotation-utils/src/main/java/edu/isi/vista/annotationutils/PushAnnotations.kt
@@ -88,6 +88,7 @@ fun main(argv: Array<String>) {
     val localWorkingCopyDirectory = File(params.getString("localWorkingCopyDirectory"))
 
     val exportedAnnotationRoot = params.getCreatableDirectory("exportedAnnotationRoot").absolutePath
+    val usernameJson = params.getOptionalExistingFile("usernameJson").orNull()
 
     // Build params for exporting the annotations
     val exportAnnotationsParamsBuilder = Parameters.builder()
@@ -96,7 +97,7 @@ fun main(argv: Array<String>) {
     exportAnnotationsParamsBuilder.set("inceptionPassword", params.getString("inceptionPassword"))
     exportAnnotationsParamsBuilder.set("exportedAnnotationRoot", exportedAnnotationRoot)
     if (params.isPresent("usernameJson")) {
-        exportAnnotationsParamsBuilder.set("usernameJson", params.getExistingFile("usernameJson").absolutePath)
+        exportAnnotationsParamsBuilder.set("usernameJson", usernameJson!!.absolutePath)
     }
     val exportAnnotationsParams = exportAnnotationsParamsBuilder.build()
 
@@ -128,6 +129,7 @@ fun main(argv: Array<String>) {
     extractAnnotationStatsParamsBuilder.set(
             "timeReportRoot", params.getCreatableDirectory("timeReportRoot").absolutePath
     )
+    extractAnnotationStatsParamsBuilder.set("usernameJson", usernameJson!!.absolutePath)
     extractAnnotationStatsParamsBuilder.set(
             "statisticsDirectory", params.getCreatableDirectory("statisticsDirectory").absolutePath
     )

--- a/sample_params/extract_annotation_stats.params
+++ b/sample_params/extract_annotation_stats.params
@@ -2,4 +2,5 @@ exportedAnnotationRoot: /Users/isiboston/Documents/projects/gaia/curatedTraining
 originalLogsRoot: /Users/isiboston/Documents/projects/gaia/curatedTraining/repos/curated-training-annotation/data/original-logs
 indicatorSearchesRoot: /Users/isiboston/Documents/projects/gaia/curatedTraining/repos/curated-training-annotation/data/indicator-searches
 timeReportRoot: /Users/isiboston/Documents/projects/gaia/curatedTraining/repos/curated-training-annotation/data/time-reports
+usernameJson: /Users/isiboston/Documents/projects/gaia/curatedTraining/repos/curated-training-annotator/docs/usernames_to_abbreviations.json
 statisticsDirectory: /Users/isiboston/Documents/projects/gaia/curatedTraining/repos/curated-training-annotation/data/annotation-statistics

--- a/sample_params/parse_event_logs.params
+++ b/sample_params/parse_event_logs.params
@@ -2,3 +2,4 @@ exportedAnnotationRoot: /Users/isiboston/Documents/projects/gaia/curatedTraining
 originalLogsRoot: /Users/isiboston/Documents/projects/gaia/curatedTraining/data/original-logs
 indicatorSearchesRoot: /Users/isiboston/Documents/projects/gaia/curatedTraining/data/indicator-searches
 timeReportRoot: /Users/isiboston/Documents/projects/gaia/curatedTraining/data/time-reports
+usernameJson: /Users/isiboston/Documents/projects/gaia/curatedTraining/data/usernames_to_abbreviations.json


### PR DESCRIPTION
Closes #100 

Along with addressing two issues surrounding the username replacement, this fixes a block of code that prevented indicator searches from being saved.