### PR TITLE
Add option to zip exports

### DIFF
--- a/annotation-utils/src/main/java/edu/isi/vista/annotationutils/PushAnnotations.kt
+++ b/annotation-utils/src/main/java/edu/isi/vista/annotationutils/PushAnnotations.kt
@@ -36,6 +36,11 @@ import java.util.concurrent.TimeUnit
  *          alternate names; use this if you want to change the annotator's name
  *          to something other than their username when saving the project files,
  *          e.g. if the username contains info that should not be shared. </li>
+ *     <li> `compressOutput` (optional) determines whether the project directories
+ *          will be copied to zip archives. The default is false. </li>
+ *     <li> `zipExportRoot` (optional) is the directory where the zipped output will be saved.
+ *          If no value is given, the output will not have a compressed version. </li>
+ *
  *     <li> `restoreJson`: "true" if you would like to restore the original document text to the annotation
  *          files; if your repository is public, please put "false"; if "true", you must also provide
  *          the following three parameter values:
@@ -54,6 +59,7 @@ import java.util.concurrent.TimeUnit
  *         <li> `curatedTrainingIngesterPath` is the path to `curated_training_ingester.py`</li>
  *       </ul>
  *     </li>
+ *
  *     <li> `statisticsDirectory` is the directory where the annotation statistics reports
  *     will be saved</li>
  *     <li> `repoToPushTo`: the ssh url of the repository to which the annotation data
@@ -97,8 +103,18 @@ fun main(argv: Array<String>) {
     exportAnnotationsParamsBuilder.set("inceptionUsername", params.getString("inceptionUsername"))
     exportAnnotationsParamsBuilder.set("inceptionPassword", params.getString("inceptionPassword"))
     exportAnnotationsParamsBuilder.set("exportedAnnotationRoot", exportedAnnotationRoot)
-    if (params.isPresent("usernameJson")) {
+    if (hasUsernameJson) {
         exportAnnotationsParamsBuilder.set("usernameJson", usernameJson!!.absolutePath)
+    }
+    if (params.isPresent("compressOutput")) {
+        exportAnnotationsParamsBuilder.set(
+                "compressOutput", params.getBoolean("compressOutput").toString()
+        )
+    }
+    if (params.isPresent("zipExportRoot")) {
+        exportAnnotationsParamsBuilder.set(
+                "zipExportRoot", params.getCreatableDirectory("zipExportRoot").absolutePath
+        )
     }
     val exportAnnotationsParams = exportAnnotationsParamsBuilder.build()
 

--- a/annotation-utils/src/main/java/edu/isi/vista/annotationutils/PushAnnotations.kt
+++ b/annotation-utils/src/main/java/edu/isi/vista/annotationutils/PushAnnotations.kt
@@ -45,18 +45,25 @@ import java.util.concurrent.TimeUnit
  *          files; if your repository is public, please put "false"; if "true", you must also provide
  *          the following three parameter values:
  *       <ul>
+ *
  *         <li> `indexDirectory` is the location of the files produced by `indexFlatGigaword.java`
 (https://github.com/isi-vista/nlp-util/blob/master/nlp-core-open/src/main/java/edu/isi/nlp/corpora/gigaword/IndexFlatGigaword.java) </li>
  *         <li> `aceEngDataDirectory` is the location of the ACE English corpus files
  *         (ace_2005_td_v7_LDC2006T06/data/English) </li>
  *         <li> `gigawordDataDirectory` is the location of the gigaword text files </li>
  *         <li> `restoredJsonDirectory` is where the new json files will go </li>
+ *
  *         <li> `annotatedFlexNLPOutputDir` is the directory where the annotated FlexNLP documents will be saved</li>
+ *         <li> `compressFlexNLPOutput` (optional) determines whether the FlexNLP project directories
+ *         will be copied to zip archives. The default is False. </li>
+ *         <li> `zipFlexNLPOutputDir` (optional) is the directory where the zipped FlexNLP output
+ *         will be saved. If no value is given, the output will not have a compressed version. </li>
  *         <li> `ingesterParametersDirectory` is where the parameters file for `curated_training_ingester.py` will
  *          be saved</li>
  *         <li> `pythonPath` is the path to the python interpreter that will be used to run
  *         `curated_training_ingester.py`</li>
  *         <li> `curatedTrainingIngesterPath` is the path to `curated_training_ingester.py`</li>
+ *
  *       </ul>
  *     </li>
  *
@@ -185,6 +192,18 @@ fun main(argv: Array<String>) {
                     "annotated_flexnlp_output_dir",
                     params.getCreatableDirectory("annotatedFlexNLPOutputDir").absolutePath
             )
+            if (params.isPresent("compressFlexNLPOutput")) {
+                curatedTrainingIngesterParamsBuilder.set(
+                        "compress_output",
+                        params.getBoolean("compressFlexNLPOutput").toString()
+                )
+            }
+            if (params.isPresent("zipFlexNLPOutputDir")) {
+                curatedTrainingIngesterParamsBuilder.set(
+                        "zip_dir",
+                        params.getCreatableDirectory("zipFlexNLPOutputDir").absolutePath
+                )
+            }
             val curatedTrainingIngesterParams = curatedTrainingIngesterParamsBuilder.build()
             val ingesterParametersDir = params.getCreatableDirectory("ingesterParametersDirectory")
                     .toPath()

--- a/sample_params/export_annotation.params
+++ b/sample_params/export_annotation.params
@@ -4,3 +4,5 @@ inceptionUsername: remote_admin
 inceptionPassword: %INCEPTION_PASSWORD%
 exportedAnnotationRoot: /Users/gabbard/projects/gaia/curated-training/exported-data
 usernamesToAbbreviations: /Users/gabbard/projects/gaia/curated-training/usernames_to_abbreviations.json
+compressOutput: true
+zipExportRoot: /Users/gabbard/projects/gaia/curated-training/repos/curated-training-annotation/data/exported

--- a/sample_params/push_annotations.lee.params
+++ b/sample_params/push_annotations.lee.params
@@ -2,7 +2,9 @@ inceptionUrl: http://curatedtraining.isi.edu:8080
 inceptionUsername: remote_admin
 # password is expected to be specified in an environmental variable
 inceptionPassword: %INCEPTION_PASSWORD%
-exportedAnnotationRoot: /Users/isiboston/Documents/projects/gaia/curatedTraining/repos/curated-training-vistanlp/data/exported
+exportedAnnotationRoot: /Users/isiboston/Documents/projects/gaia/curatedTraining/data/exported
+compressOutput: false
+zipExportRoot: /Users/isiboston/Documents/projects/gaia/curatedTraining/repos/curated-training-vistanlp/data/exported
 
 restoreJson: false
 aceEngDataDirectory: /Users/isiboston/Documents/projects/gaia/curatedTraining/corpora/ace_2005_td_v7_LDC2006T06/data/English


### PR DESCRIPTION
This PR aims to support the changes to the annotation data storage described in #105 .

Connected to this is https://github.com/isi-vista/gaia-event-extraction/pull/213 .

Note that even if the user chooses the "compress" option, the uncompressed output will still be saved to the designated directory. I think it would make sense to eventually allow the other steps in the pipeline to be able to read from zip archives so that the output can be "either compressed or not," but I would rather handle this in another issue.