### PR TITLE
Upgrade JGit

### DIFF
--- a/annotation-utils/src/main/java/edu/isi/vista/annotationutils/PushAnnotations.kt
+++ b/annotation-utils/src/main/java/edu/isi/vista/annotationutils/PushAnnotations.kt
@@ -131,6 +131,7 @@ fun main(argv: Array<String>) {
         Parameters.builder()
                 .set("indexDirectory", params.getExistingDirectory("indexDirectory").absolutePath)
                 .set("aceEngDataDirectory", params.getExistingDirectory("aceEngDataDirectory").absolutePath)
+                .set("cord19DataDirectory", params.getExistingDirectory("cord19DataDirectory").absolutePath)
                 .set("gigawordDataDirectory", params.getExistingDirectory("gigawordDataDirectory").absolutePath)
                 .set("inputJsonDirectory", exportedAnnotationRoot)
                 .set("restoredJsonDirectory", params.getCreatableDirectory("restoredJsonDirectory").absolutePath)

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
 			<dependency>
 				<groupId>org.eclipse.jgit</groupId>
 				<artifactId>org.eclipse.jgit</artifactId>
-				<version>5.4.0.201906121030-r</version>
+				<version>5.5.0.201909110433-r</version>
 			</dependency>
 			<dependency>
 				<groupId>org.immutables</groupId>


### PR DESCRIPTION
Upgrades JGit to version `5.5.0.201909110433-r`, which contains a fix preventing the repository setup from getting stuck in a while-loop.

Also adds a parameter that was missing from the pushAnnotations setup